### PR TITLE
Fix SparkRedisIntegration import and syntax

### DIFF
--- a/SparkRedisIntegration.py
+++ b/SparkRedisIntegration.py
@@ -10,10 +10,13 @@ Workflow:
 """
 
 # create spark session
-spark = SparkSession \
-        .builder \
-        .appName("Spark Redis Integration") \
+from pyspark.sql import SparkSession
+
+spark = (
+    SparkSession.builder
+        .appName("Spark Redis Integration")
         .getOrCreate()
+)
 
 
 # create dummy dataframe
@@ -26,8 +29,11 @@ df = spark.createDataFrame([[1, "abc", 5, "2024-05-09"],
 
 # write spark dataframe to Redis
 # table is equivalent prefix in Redis
-df.write.format("org.apache.spark.sql.redis") \
-    .option("table", "user") \ # Redis Prefix
-    .option("key.column", "user_id") \ # Unique Key
-    .option("host", "localhost") \
-    .option("port", "6379").save()
+(
+    df.write.format("org.apache.spark.sql.redis")
+      .option("table", "user")   # Redis Prefix
+      .option("key.column", "user_id")   # Unique Key
+      .option("host", "localhost")
+      .option("port", "6379")
+      .save()
+)


### PR DESCRIPTION
## Summary
- add missing `SparkSession` import
- fix syntax error in write-to-Redis call by using parentheses

## Testing
- `python -m py_compile AirflowCallbackFunctions.py SparkFernetIntegration.py SparkRedisIntegration.py`


------
https://chatgpt.com/codex/tasks/task_e_688a401b5df88322b95230ffe6907dd5